### PR TITLE
New Feature - Dedicated MegaMenu Cache

### DIFF
--- a/Block/Menu.php
+++ b/Block/Menu.php
@@ -322,8 +322,8 @@ class Menu extends \Magento\Catalog\Block\Navigation
                     $url = '<a href="' . $child->getUrl() . '"><span>' . __($child->getName()) . $this->getCatLabel($child) . '</span></a>';
                     $childHtml = ($this->_recursionLevel != 2) ? $this->getTreeCategoriesExt($child->getId(), $itemPositionClassPrefixChild) : ''; // include magic_label
                     // $childHtml = ($this->_recursionLevel != 2 ) ? $this->getTreeCategoriesExtra($child->getId()) : ''; // include magic_label and Maximal Depth
-                    $desktopTmp .= '<li class="children ' . $class . '" data-categoryid="' . $child->getId() . ' ">' . $this->getImage($child) . $url . $childHtml . '</li>';
-                    $mobileTmp .= '<li class="' . $class . '">' . $url . $childHtml . '</li>';
+                    $desktopTmp .= '<li class="children ' . $class . '" data-categoryid="' . $child->getId() . '">' . $this->getImage($child) . $url . $childHtml . '</li>';
+                    $mobileTmp .= '<li class="' . $class . '" data-categoryid="' . $child->getId() . '">' . $url . $childHtml . '</li>';
                     $counter++;
                 }
                 //$desktopTmp .= '<li>'  .$blocks['bottom']. '</li>';
@@ -422,7 +422,7 @@ class Menu extends \Magento\Catalog\Block\Navigation
             $childHtml = ($this->_recursionLevel == 0 || ($level - 1 < $this->_recursionLevel)) ? $this->getTreeCategoriesExt($category->getId(), $itemPositionClassPrefix) : '';
             $childClass = $childHtml ? ' hasChild parent category-item ' : ' category-item ';
             $childClass .= $itemPositionClassPrefix . '-' . $counter;
-            $html .= '<li class="level' . ($level - 2) . $childClass . '" data-categoryid="' . $category->getId() . ' "><a href="' . $category->getUrl() . '"><span>' . $category->getName() . $this->getCatLabel($category) . "</span></a>\n" . $childHtml . '</li>';
+            $html .= '<li class="level' . ($level - 2) . $childClass . '" data-categoryid="' . $category->getId() . '"><a href="' . $category->getUrl() . '"><span>' . $category->getName() . $this->getCatLabel($category) . "</span></a>\n" . $childHtml . '</li>';
             $counter++;
         }
         if ($html) $html = '<ul class="level' . ($level - 3) . ' submenu">' . $html . '</ul>';
@@ -441,7 +441,7 @@ class Menu extends \Magento\Catalog\Block\Navigation
             $childHtml = ($this->_recursionLevel == 0 || ($level - 1 < $this->_recursionLevel)) ? $this->getTreeCategoriesExtra($category->getId(), $itemPositionClassPrefix) : '';
             $childClass = $childHtml ? ' hasChild parent' : '';
             $childClass .= $itemPositionClassPrefix . '-' . $counter;
-            $html .= '<li class="level' . ($level - 2) . $childClass . '" data-=categoryid"' . $category->getId() . ' "><a href="' . $this->getCategoryUrl($category) . '"><span>' . $cat->getName() . "(" . $count . ")" . $this->getCatLabel($cat) . "</span></a>\n";
+            $html .= '<li class="level' . ($level - 2) . $childClass . '" data-=categoryid"' . $category->getId() . '"><a href="' . $this->getCategoryUrl($category) . '"><span>' . $cat->getName() . "(" . $count . ")" . $this->getCatLabel($cat) . "</span></a>\n";
             $html .= $childHtml;
             $html .= '</li>';
             $counter++;

--- a/Block/Menu.php
+++ b/Block/Menu.php
@@ -303,6 +303,8 @@ class Menu extends \Magento\Catalog\Block\Navigation
     {
         // Draw Mega Menu
         $idTop = $catTop->getEntityId();
+        if(count($this->getChildExt($idTop)) < 1) return;
+
         $hasChild = $catTop->hasChildren();
         $desktopTmp = $mobileTmp = '';
         if ($hasChild || $blocks['top'] || $blocks['left'] || $blocks['right'] || $blocks['bottom']) :

--- a/Block/Menu.php
+++ b/Block/Menu.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Magiccart 
- * @category  Magiccart 
- * @copyright   Copyright (c) 2014 Magiccart (http://www.magiccart.net/) 
+ * Magiccart
+ * @category  Magiccart
+ * @copyright   Copyright (c) 2014 Magiccart (http://www.magiccart.net/)
  * @license   http://www.magiccart.net/license-agreement.html
  * @Author: Magiccart<team.magiccart@gmail.com>
  * @@Create Date: 2016-02-28 10:10:00
@@ -110,7 +110,8 @@ class Menu extends \Magento\Catalog\Block\Navigation
         \Magiccart\Magicmenu\Model\ResourceModel\Magicmenu\CollectionFactory $magicmenuCollectionFactory,
 
         array $data = []
-    ) {
+    )
+    {
 
         $this->_productCollectionFactory = $productCollectionFactory;
         $this->_catalogLayer = $layerResolver->get();
@@ -123,7 +124,7 @@ class Menu extends \Magento\Catalog\Block\Navigation
 
         // +++++++++add new +++++++++
         $this->_magicmenuCollectionFactory = $magicmenuCollectionFactory;
-        $this->_sysCfg= (object) $context->getScopeConfig()->getValue(
+        $this->_sysCfg = (object)$context->getScopeConfig()->getValue(
             'magicmenu',
             \Magento\Store\Model\ScopeInterface::SCOPE_STORE
         );
@@ -131,8 +132,8 @@ class Menu extends \Magento\Catalog\Block\Navigation
         parent::__construct($context, $categoryFactory, $productCollectionFactory, $layerResolver, $httpContext, $catalogCategory, $registry, $flatState, $data);
 
         $this->_urlMedia = $this->_storeManager->getStore()->getBaseUrl(
-                \Magento\Framework\UrlInterface::URL_TYPE_MEDIA
-            );
+            \Magento\Framework\UrlInterface::URL_TYPE_MEDIA
+        );
 
         $this->_dirMedia = $this->getMediaDirectory()->getAbsolutePath();
 
@@ -145,36 +146,11 @@ class Menu extends \Magento\Catalog\Block\Navigation
         );
 
 
-
     }
 
     public function getIsHomePage()
     {
-        return $this->getUrl('') == $this->getUrl('*/*/*', array('_current'=>true, '_use_rewrite'=>true));
-    }
-
-    public function isCategoryActive($catId)
-    {
-        return $this->getCurrentCategory() ? in_array($catId, $this->getCurrentCategory()->getPathIds()) : false;
-    }
-
-    public function isHasActive($catId)
-    {
-        return ($catId != $this->getCurrentCategory()->getId()) ? true : false;
-    }
-
-    protected function _getActiveClasses($catId)
-    {
-        $classes = '';
-        if ($this->isCategoryActive($catId)) {
-            if($this->isHasActive($catId)){
-                $classes = 'has-active active';
-            } else {
-                $classes = 'active';
-            }
-            
-        }
-        return $classes;
+        return $this->getUrl('') == $this->getUrl('*/*/*', array('_current' => true, '_use_rewrite' => true));
     }
 
     public function getLogo()
@@ -190,19 +166,19 @@ class Menu extends \Magento\Catalog\Block\Navigation
 
     public function drawHomeMenu()
     {
-        if($this->hasData('homeMenu')) return $this->getData('homeMenu');
+        if ($this->hasData('homeMenu')) return $this->getData('homeMenu');
         $drawHomeMenu = '';
-        $active = ($this->getIsHomePage()) ? ' active' : '';
-        $drawHomeMenu .= '<li class="level0 category-item level-top dropdown home' . $active . '">';
-        $drawHomeMenu .= '<a class="level-top" href="'.$this->getBaseUrl().'"><span class="icon fa fa-home"></span><span class="icon-text">' .__('Home') .'</span>';
+
+        $drawHomeMenu .= '<li class="level0 category-item level-top dropdown home" >';
+        $drawHomeMenu .= '<a class="level-top" href="' . $this->getBaseUrl() . '"><span class="icon fa fa-home"></span><span class="icon-text">' . __('Home') . '</span>';
         $drawHomeMenu .= '</a>';
-        if($this->_sysCfg->topmenu['demo']){
+        if ($this->_sysCfg->topmenu['demo']) {
             $demo = '';
             $currentStore = $this->_storeManager->getStore();
             $switcher = $this->getLayout()->createBlock('Magento\Store\Block\Switcher');
             foreach ($this->_storeManager->getWebsites() as $website) {
                 $groups = $website->getGroups();
-                if(count($groups) > 1){
+                if (count($groups) > 1) {
                     foreach ($groups as $group) {
                         $store = $group->getDefaultStore();
                         if ($store && !$store->getIsActive()) {
@@ -211,17 +187,17 @@ class Menu extends \Magento\Catalog\Block\Navigation
                                 if ($store->getIsActive()) break;
                                 else $store = '';
                             }
-                        }                     
-                        if($store){
-                            if( $store->getCode() == $currentStore->getCode() )  $demo .= '<li class="level1"><a href="' .$store->getBaseUrl(). '"><span class="demo-home">'. $group->getName(). '</span></a></li>';
-                            else $demo .= '<li class="switcher-option level1"><a href="#" data-post='. $switcher->getTargetStorePostData($store) . '><span class="demo-home">'. $group->getName(). '</span></a></li>';
+                        }
+                        if ($store) {
+                            if ($store->getCode() == $currentStore->getCode()) $demo .= '<li class="level1"><a href="' . $store->getBaseUrl() . '"><span class="demo-home">' . $group->getName() . '</span></a></li>';
+                            else $demo .= '<li class="switcher-option level1"><a href="#" data-post=' . $switcher->getTargetStorePostData($store) . '><span class="demo-home">' . $group->getName() . '</span></a></li>';
 
 
                         }
                     }
                 }
             }
-            if($demo) $drawHomeMenu .= '<ul class="level0 category-item submenu">' .$demo .'</ul>';           
+            if ($demo) $drawHomeMenu .= '<ul class="level0 category-item submenu">' . $demo . '</ul>';
         }
 
         $drawHomeMenu .= '</li>';
@@ -231,7 +207,7 @@ class Menu extends \Magento\Catalog\Block\Navigation
 
     public function drawMainMenu()
     {
-        if($this->hasData('mainMenu')) return $this->getData('mainMenu');
+        if ($this->hasData('mainMenu')) return $this->getData('mainMenu');
 
         /*
             * Check if menu is saved in cache
@@ -239,7 +215,7 @@ class Menu extends \Magento\Catalog\Block\Navigation
         $cacheId = $this->_cacheHelper->getId("mainMenu");
         $mobilecacheId = $this->_cacheHelper->getId("mobileMenu");
 
-        if($cache = $this->_cacheHelper->load($cacheId)){
+        if ($cache = $this->_cacheHelper->load($cacheId)) {
 
             $menu = array();
 
@@ -255,10 +231,10 @@ class Menu extends \Magento\Catalog\Block\Navigation
         }
 
         $desktopHtml = array();
-        $mobileHtml  = array();
+        $mobileHtml = array();
         $rootCatId = $this->_storeManager->getStore()->getRootCategoryId();
         $catListTop = $this->getChildExt($rootCatId);
-        $contentCatTop  = $this->getContentCatTop();
+        $contentCatTop = $this->getContentCatTop();
 
         foreach ($contentCatTop as $ext) {
             $this->extData[$ext->getCatId()] = $ext->getData();
@@ -266,52 +242,52 @@ class Menu extends \Magento\Catalog\Block\Navigation
         $last = count($catListTop);
         $dropdownIds = explode(',', $this->_sysCfg->general['dropdown']);
         $counter = 1;
-        
-        foreach ($catListTop as $catTop){
+
+        foreach ($catListTop as $catTop) {
             $parentPositionClass = '';
             $itemPositionClassPrefix = $parentPositionClass ? $parentPositionClass . '-' : 'nav-';
-            $idTop    = $catTop->getEntityId();
-            $urlTop      =  '<a class="level-top" href="' .$catTop->getUrl(). '">' .$this->getThumbnail($catTop). '<span>' .__($catTop->getName()) . $this->getCatLabel($catTop). '</span><span class="boder-menu"></span></a>';
+            $idTop = $catTop->getEntityId();
+            $urlTop = '<a class="level-top" href="' . $catTop->getUrl() . '" data-categoryid="' . $catTop->getId() . '" >' . $this->getThumbnail($catTop) . '<span>' . __($catTop->getName()) . $this->getCatLabel($catTop) . '</span><span class="boder-menu"></span></a>';
 
             $itemPositionClassPrefixTop = $itemPositionClassPrefix . $counter;
-            $classTop   = $itemPositionClassPrefixTop . ' ' . $this->_getActiveClasses($idTop);
+            $classTop = $itemPositionClassPrefixTop;
             $isDropdown = in_array($idTop, $dropdownIds) ? ' dropdown' : '';
             // drawMainMenu
-            $options  = '';
-            if($this->_recursionLevel == 1){
-                $menu = array('desktop' => '', 'mobile' => '');               
-            }else {
-                if($isDropdown){
+            $options = '';
+            if ($this->_recursionLevel == 1) {
+                $menu = array('desktop' => '', 'mobile' => '');
+            } else {
+                if ($isDropdown) {
                     $classTop .= $isDropdown;
                     $childHtml = $this->getTreeCategoriesExt($idTop, $itemPositionClassPrefixTop); // include magic_label
                     // $childHtml = $this->getTreeCategoriesExtra($idTop, $itemPositionClassPrefixTop); // include magic_label and Maximal Depth
                     $menu = array('desktop' => $childHtml, 'mobile' => $childHtml);
                 } else { // Draw Mega Menu
-                    $idTop    = $catTop->getEntityId();
-                    $data     = isset($this->extData[$idTop]) ? $this->extData[$idTop] : '';
-                    $blocks   = array('top'=>'', 'left'=>'', 'right'=>'', 'bottom'=>'');
-                    if($data){
+                    $idTop = $catTop->getEntityId();
+                    $data = isset($this->extData[$idTop]) ? $this->extData[$idTop] : '';
+                    $blocks = array('top' => '', 'left' => '', 'right' => '', 'bottom' => '');
+                    if ($data) {
                         foreach ($blocks as $key => $value) {
-                            $proportion = $key .'_proportion';
+                            $proportion = $key . '_proportion';
                             $html = $this->getStaticBlock($data[$key]);
-                            if($html) $blocks[$key] = "<div class='mage-column mega-block-$key'>".$html.'</div>';
+                            if ($html) $blocks[$key] = "<div class='mage-column mega-block-$key'>" . $html . '</div>';
                         }
-                        $remove = array('top'=>'', 'left'=>'', 'right'=>'', 'bottom'=>'', 'cat_id'=>'');
+                        $remove = array('top' => '', 'left' => '', 'right' => '', 'bottom' => '', 'cat_id' => '');
                         foreach ($remove as $key => $value) {
                             unset($data[$key]);
                         }
-                        $opt     = json_encode($data);
+                        $opt = json_encode($data);
                         $options = $opt ? " data-options='$opt'" : '';
                     }
                     $menu = $this->getMegamenu($catTop, $blocks, $itemPositionClassPrefixTop);
-                }               
+                }
             }
 
-            if($menu['desktop']) $classTop .= ' hasChild parent';
+            if ($menu['desktop']) $classTop .= ' hasChild parent';
 
-            $desktopHtml[$idTop] = '<li class="level0 category-item level-top cat ' . $classTop . '"' . $options .'>' . $urlTop . $menu['desktop'] . '</li>';
-            $mobileHtml[$idTop]  = '<li class="level0 category-item level-top cat ' . $classTop . '">' . $urlTop . $menu['mobile'] . '</li>';
-            $counter++;     
+            $desktopHtml[$idTop] = '<li class="level0 category-item level-top cat ' . $classTop . '"' . $options . '>' . $urlTop . $menu['desktop'] . '</li>';
+            $mobileHtml[$idTop] = '<li class="level0 category-item level-top cat ' . $classTop . '">' . $urlTop . $menu['mobile'] . '</li>';
+            $counter++;
         }
         $menu['desktop'] = $desktopHtml;
         $menu['mobile'] = implode("\n", $mobileHtml);
@@ -325,39 +301,39 @@ class Menu extends \Magento\Catalog\Block\Navigation
 
     public function getMegamenu($catTop, $blocks, $itemPositionClassPrefix)
     {
-        // Draw Mega Menu 
-        $idTop    = $catTop->getEntityId();
+        // Draw Mega Menu
+        $idTop = $catTop->getEntityId();
         $hasChild = $catTop->hasChildren();
-        $desktopTmp = $mobileTmp  = '';
-        if($hasChild || $blocks['top'] || $blocks['left'] || $blocks['right'] || $blocks['bottom']) :
+        $desktopTmp = $mobileTmp = '';
+        if ($hasChild || $blocks['top'] || $blocks['left'] || $blocks['right'] || $blocks['bottom']) :
             $desktopTmp .= '<div class="level-top-mega">';  /* Wrap Mega */
-                $desktopTmp .='<div class="content-mega">';  /*  Content Mega */
-                    $desktopTmp .= $blocks['top'];
-                    $desktopTmp .= '<div class="content-mega-horizontal">';
-                        $desktopTmp .= $blocks['left'];
-                        if($hasChild) :
-                            $desktopTmp .= '<ul class="level0 category-item mage-column cat-mega">';
-                            $mobileTmp .= '<ul class="submenu">';
-                            $childTop  =  $this->getChildExt($idTop);
-                            $counter = 1;
-                            foreach ($childTop as $child) {
-                                $itemPositionClassPrefixChild = $itemPositionClassPrefix . '-' . $counter;
-                                $class = 'level1 category-item ' . $itemPositionClassPrefixChild . ' ' . $this->_getActiveClasses($child->getId());
-                                $url =  '<a href="'. $child->getUrl().'"><span>'.__($child->getName()) . $this->getCatLabel($child) . '</span></a>';
-                                $childHtml = ($this->_recursionLevel != 2 ) ? $this->getTreeCategoriesExt($child->getId(), $itemPositionClassPrefixChild) : ''; // include magic_label
-                                // $childHtml = ($this->_recursionLevel != 2 ) ? $this->getTreeCategoriesExtra($child->getId()) : ''; // include magic_label and Maximal Depth
-                                $desktopTmp .= '<li class="children ' . $class . '">' . $this->getImage($child) . $url . $childHtml . '</li>';
-                                $mobileTmp  .= '<li class="' . $class . '">' . $url . $childHtml . '</li>';
-                                $counter++;
-                            }
-                            //$desktopTmp .= '<li>'  .$blocks['bottom']. '</li>';
-                            $desktopTmp .= '</ul>'; // end cat-mega
-                            $mobileTmp .= '</ul>';
-                        endif;
-                        $desktopTmp .= $blocks['right'];
-                    $desktopTmp .= '</div>';
-                    $desktopTmp .= $blocks['bottom'];
-                $desktopTmp .= '</div>';  /* End Content mega */
+            $desktopTmp .= '<div class="content-mega">';  /*  Content Mega */
+            $desktopTmp .= $blocks['top'];
+            $desktopTmp .= '<div class="content-mega-horizontal">';
+            $desktopTmp .= $blocks['left'];
+            if ($hasChild) :
+                $desktopTmp .= '<ul class="level0 category-item mage-column cat-mega">';
+                $mobileTmp .= '<ul class="submenu">';
+                $childTop = $this->getChildExt($idTop);
+                $counter = 1;
+                foreach ($childTop as $child) {
+                    $itemPositionClassPrefixChild = $itemPositionClassPrefix . '-' . $counter;
+                    $class = 'level1 category-item ' . $itemPositionClassPrefixChild;
+                    $url = '<a href="' . $child->getUrl() . '"><span>' . __($child->getName()) . $this->getCatLabel($child) . '</span></a>';
+                    $childHtml = ($this->_recursionLevel != 2) ? $this->getTreeCategoriesExt($child->getId(), $itemPositionClassPrefixChild) : ''; // include magic_label
+                    // $childHtml = ($this->_recursionLevel != 2 ) ? $this->getTreeCategoriesExtra($child->getId()) : ''; // include magic_label and Maximal Depth
+                    $desktopTmp .= '<li class="children ' . $class . '" data-categoryid="' . $child->getId() . ' ">' . $this->getImage($child) . $url . $childHtml . '</li>';
+                    $mobileTmp .= '<li class="' . $class . '">' . $url . $childHtml . '</li>';
+                    $counter++;
+                }
+                //$desktopTmp .= '<li>'  .$blocks['bottom']. '</li>';
+                $desktopTmp .= '</ul>'; // end cat-mega
+                $mobileTmp .= '</ul>';
+            endif;
+            $desktopTmp .= $blocks['right'];
+            $desktopTmp .= '</div>';
+            $desktopTmp .= $blocks['bottom'];
+            $desktopTmp .= '</div>';  /* End Content mega */
             $desktopTmp .= '</div>';  /* Warp Mega */
         endif;
         return array('desktop' => $desktopTmp, 'mobile' => $mobileTmp);
@@ -365,27 +341,26 @@ class Menu extends \Magento\Catalog\Block\Navigation
 
     public function drawExtraMenu()
     {
-        if($this->hasData('extraMenu')) return $this->getData('extraMenu');
-        $extMenu    = $this->getExtraMenu();
+        if ($this->hasData('extraMenu')) return $this->getData('extraMenu');
+        $extMenu = $this->getExtraMenu();
         $count = count($extMenu);
         $drawExtraMenu = '';
-        if($count){
-            $i = 1; $class = 'first';
+        if ($count) {
+            $i = 1;
+            $class = 'first';
             $currentUrl = $this->getUrl('*/*/*', ['_current' => true, '_use_rewrite' => true]); //$this->getCurrentUrl();
-            foreach ($extMenu as $ext) { 
+            foreach ($extMenu as $ext) {
                 $link = $ext->getLink();
-                $url = (filter_var($link, FILTER_VALIDATE_URL)) ? $link : $this->getUrl('', array('_direct'=>$link));
-                $active = ( $link && $url == $currentUrl) ? ' active' : '';
+                $url = (filter_var($link, FILTER_VALIDATE_URL)) ? $link : $this->getUrl('', array('_direct' => $link));
                 $html = $this->getStaticBlock($ext->getExtContent());
                 $class .= $ext->getCatCol() ? ' ' . $ext->getCatCol() : ' dropdown';
-                if($html) $active .=' hasChild parent';
-                $drawExtraMenu .= "<li class='level0 category-item level-top ext $active $class'>";
-                    if($link) $drawExtraMenu .= '<a class="level-top" href="' .$url. '"><span>' .__($ext->getName()) . $this->getCatLabel($ext). '</span></a>';
-                    else $drawExtraMenu .= '<span class="level-top"><span>' .__($ext->getName()) . $this->getCatLabel($ext). '</span></span>';
-                    if($html) $drawExtraMenu .= $html; //$drawExtraMenu .= '<div class="level-top-mega">'.$html.'</div>';
+                $drawExtraMenu .= "<li class='level0 category-item level-top ext $class'  >";
+                if ($link) $drawExtraMenu .= '<a class="level-top" href="' . $url . '"><span>' . __($ext->getName()) . $this->getCatLabel($ext) . '</span></a>';
+                else $drawExtraMenu .= '<span class="level-top"><span>' . __($ext->getName()) . $this->getCatLabel($ext) . '</span></span>';
+                if ($html) $drawExtraMenu .= $html; //$drawExtraMenu .= '<div class="level-top-mega">'.$html.'</div>';
                 $drawExtraMenu .= '</li>';
                 $i++;
-                $class = ($i == $count) ? 'last' : '';  
+                $class = ($i == $count) ? 'last' : '';
             }
         }
         $this->setData('extraMenu', $drawExtraMenu);
@@ -395,11 +370,11 @@ class Menu extends \Magento\Catalog\Block\Navigation
     public function getChildExt($parentId)
     {
         $collection = $this->_categoryInstance->getCollection()
-                        ->addAttributeToSelect(array('entity_id','name','magic_label','url_path'))
-                        ->addAttributeToFilter('parent_id', $parentId)
-                        ->addAttributeToFilter('include_in_menu', 1)
-                        ->addIsActiveFilter()
-                        ->addAttributeToSort('position', 'asc'); //->addOrderField('name');
+            ->addAttributeToSelect(array('entity_id', 'name', 'magic_label', 'url_path'))
+            ->addAttributeToFilter('parent_id', $parentId)
+            ->addAttributeToFilter('include_in_menu', 1)
+            ->addIsActiveFilter()
+            ->addAttributeToSort('position', 'asc'); //->addOrderField('name');
         return $collection;
     }
 
@@ -407,11 +382,11 @@ class Menu extends \Magento\Catalog\Block\Navigation
     {
         $store = $this->_storeManager->getStore()->getStoreId();
         $collection = $this->_magicmenuCollectionFactory->create()
-                        ->addFieldToSelect(array('link','name', 'cat_col', 'magic_label','ext_content','order'))
-                        ->addFieldToFilter('extra', 1)
-                        ->addFieldToFilter('status', 1);
+            ->addFieldToSelect(array('link', 'name', 'cat_col', 'magic_label', 'ext_content', 'order'))
+            ->addFieldToFilter('extra', 1)
+            ->addFieldToFilter('status', 1);
         $collection->getSelect()->where('find_in_set(0, stores) OR find_in_set(?, stores)', $store)->order('order');
-        return $collection;        
+        return $collection;
     }
 
     public function getStaticBlock($id)
@@ -423,59 +398,56 @@ class Menu extends \Magento\Catalog\Block\Navigation
     {
         $store = $this->_storeManager->getStore()->getStoreId();
         $collection = $this->_magicmenuCollectionFactory->create()
-                        ->addFieldToSelect(array(
-                                'cat_id','cat_col','cat_proportion','top',
-                                'right','right_proportion','bottom','left','left_proportion'
-                            ))
-                        ->addFieldToFilter('stores',array( array('finset' => 0), array('finset' => $store)))
-                        ->addFieldToFilter('status', 1);
+            ->addFieldToSelect(array(
+                'cat_id', 'cat_col', 'cat_proportion', 'top',
+                'right', 'right_proportion', 'bottom', 'left', 'left_proportion'
+            ))
+            ->addFieldToFilter('stores', array(array('finset' => 0), array('finset' => $store)))
+            ->addFieldToFilter('status', 1);
         return $collection;
     }
 
-    public function  getTreeCategoriesExt($parentId, $itemPositionClassPrefix) // include Magic_Label
-    { 
+    public function getTreeCategoriesExt($parentId, $itemPositionClassPrefix) // include Magic_Label
+    {
         $categories = $this->_categoryInstance->getCollection()
-                        ->addAttributeToSelect(array('name','magic_label','url_path'))
-                        ->addAttributeToFilter('include_in_menu', 1)
-                        ->addAttributeToFilter('parent_id', $parentId)
-                        ->addIsActiveFilter()
-                        ->addAttributeToSort('position', 'asc'); 
+            ->addAttributeToSelect(array('name', 'magic_label', 'url_path'))
+            ->addAttributeToFilter('include_in_menu', 1)
+            ->addAttributeToFilter('parent_id', $parentId)
+            ->addIsActiveFilter()
+            ->addAttributeToSort('position', 'asc');
         $html = '';
         $counter = 1;
-        foreach($categories as $category)
-        {
+        foreach ($categories as $category) {
             $level = $category->getLevel();
-            $childHtml = ( $this->_recursionLevel == 0 || ($level -1 < $this->_recursionLevel) ) ? $this->getTreeCategoriesExt($category->getId(), $itemPositionClassPrefix) : '';
+            $childHtml = ($this->_recursionLevel == 0 || ($level - 1 < $this->_recursionLevel)) ? $this->getTreeCategoriesExt($category->getId(), $itemPositionClassPrefix) : '';
             $childClass = $childHtml ? ' hasChild parent category-item ' : ' category-item ';
-            $childClass .= $itemPositionClassPrefix . '-' .$counter;
-            $childClass .= $this->_getActiveClasses($category->getId());
-            $html .= '<li class="level' . ($level -2) . $childClass . '"><a href="' . $category->getUrl() . '"><span>' . $category->getName() . $this->getCatLabel($category) . "</span></a>\n" . $childHtml . '</li>';
+            $childClass .= $itemPositionClassPrefix . '-' . $counter;
+            $html .= '<li class="level' . ($level - 2) . $childClass . '" data-categoryid="' . $category->getId() . ' "><a href="' . $category->getUrl() . '"><span>' . $category->getName() . $this->getCatLabel($category) . "</span></a>\n" . $childHtml . '</li>';
             $counter++;
         }
-        if($html) $html = '<ul class="level'.($level -3).' submenu">' .$html. '</ul>';
+        if ($html) $html = '<ul class="level' . ($level - 3) . ' submenu">' . $html . '</ul>';
         return $html;
     }
 
-    public function  getTreeCategoriesExtra($parentId, $itemPositionClassPrefix) // include Magic_Label and Maximal Depth
+    public function getTreeCategoriesExtra($parentId, $itemPositionClassPrefix) // include Magic_Label and Maximal Depth
     {
         $html = '';
         $categories = $this->_categoryInstance->getCategories($parentId);
         $counter = 1;
-        foreach($categories as $category) {
+        foreach ($categories as $category) {
             $cat = $this->_categoryInstance->load($category->getId());
             $count = $cat->getProductCount();
             $level = $cat->getLevel();
-            $childHtml = ( $this->_recursionLevel == 0 || ($level -1 < $this->_recursionLevel) ) ? $this->getTreeCategoriesExtra($category->getId(), $itemPositionClassPrefix) : '';
-            $childClass  = $childHtml ? ' hasChild parent' : '';
-            $childClass .= $itemPositionClassPrefix . '-' .$counter;
-            $childClass .= ' category-item ' . $this->_getActiveClasses($category->getId());
-            $html .= '<li class="level' . ($level -2) . $childClass . '"><a href="' . $this->getCategoryUrl($category) . '"><span>' . $cat->getName() . "(".$count.")" . $this->getCatLabel($cat) . "</span></a>\n";
+            $childHtml = ($this->_recursionLevel == 0 || ($level - 1 < $this->_recursionLevel)) ? $this->getTreeCategoriesExtra($category->getId(), $itemPositionClassPrefix) : '';
+            $childClass = $childHtml ? ' hasChild parent' : '';
+            $childClass .= $itemPositionClassPrefix . '-' . $counter;
+            $html .= '<li class="level' . ($level - 2) . $childClass . '" data-=categoryid"' . $category->getId() . ' "><a href="' . $this->getCategoryUrl($category) . '"><span>' . $cat->getName() . "(" . $count . ")" . $this->getCatLabel($cat) . "</span></a>\n";
             $html .= $childHtml;
             $html .= '</li>';
             $counter++;
         }
-        if($html) $html = '<ul class="level' .($level -3). ' submenu">' . $html . '</ul>';
-        return  $html;
+        if ($html) $html = '<ul class="level' . ($level - 3) . ' submenu">' . $html . '</ul>';
+        return $html;
     }
 
     public function getCatLabel($cat)
@@ -483,7 +455,7 @@ class Menu extends \Magento\Catalog\Block\Navigation
         $html = '';
         $label = explode(',', $cat->getMagicLabel());
         foreach ($label as $lab) {
-          if($lab) $html .= '<span class="cat_label '.$lab.'">'.__(trim($lab)) .'</span>';
+            if ($lab) $html .= '<span class="cat_label ' . $lab . '">' . __(trim($lab)) . '</span>';
         }
         return $html;
     }
@@ -491,17 +463,17 @@ class Menu extends \Magento\Catalog\Block\Navigation
     public function getImage($object)
     {
         $url = '';
-        $image = $this->_dirMedia . 'magiccart/magicmenu/images/' . $object->getId() .'.png';
-        if(file_exists($image)) $url = $this->_urlMedia . 'magiccart/magicmenu/images/' . $object->getId() .'.png';
-        if($url) return '<a class="a-image" href="' .$object->getUrl(). '"><img class="img-responsive" alt="' .$object->getName(). '" src="'.$url.'"></a>';
+        $image = $this->_dirMedia . 'magiccart/magicmenu/images/' . $object->getId() . '.png';
+        if (file_exists($image)) $url = $this->_urlMedia . 'magiccart/magicmenu/images/' . $object->getId() . '.png';
+        if ($url) return '<a class="a-image" href="' . $object->getUrl() . '"><img class="img-responsive" alt="' . $object->getName() . '" src="' . $url . '"></a>';
     }
 
     public function getThumbnail($object)
     {
         $url = '';
-        $image = $this->_dirMedia . 'magiccart/magicmenu/thumbnail/' . $object->getId() .'.png';
-        if(file_exists($image)) $url = $this->_urlMedia . 'magiccart/magicmenu/thumbnail/' . $object->getId() .'.png';
-        if($url) return '<img class="img-responsive" alt="' .$object->getName(). '" src="'.$url.'">';
+        $image = $this->_dirMedia . 'magiccart/magicmenu/thumbnail/' . $object->getId() . '.png';
+        if (file_exists($image)) $url = $this->_urlMedia . 'magiccart/magicmenu/thumbnail/' . $object->getId() . '.png';
+        if ($url) return '<img class="img-responsive" alt="' . $object->getName() . '" src="' . $url . '">';
     }
 
 }

--- a/Helper/Cache.php
+++ b/Helper/Cache.php
@@ -1,0 +1,76 @@
+<?php
+
+
+namespace Magiccart\Magicmenu\Helper;
+
+use Magento\Framework\App\Helper;
+
+class Cache extends Helper\AbstractHelper
+{
+    const CACHE_TAG = 'MEGAMENU';
+    const CACHE_ID = 'megamenu';
+    const CACHE_LIFETIME = 86400;
+
+    protected $cache;
+    protected $cacheState;
+    protected $storeManager;
+    private $storeId;
+
+    /**
+     * Cache constructor.
+     * @param Helper\Context $context
+     * @param \Magento\Framework\App\Cache $cache
+     * @param \Magento\Framework\App\Cache\State $cacheState
+     * @param \Magento\Store\Model\StoreManagerInterface $storeManager
+     */
+    public function __construct(
+        Helper\Context $context,
+        \Magento\Framework\App\Cache $cache,
+        \Magento\Framework\App\Cache\State $cacheState,
+        \Magento\Store\Model\StoreManagerInterface $storeManager
+    ) {
+        $this->cache = $cache;
+        $this->cacheState = $cacheState;
+        $this->storeManager = $storeManager;
+        $this->storeId = $storeManager->getStore()->getId();
+        parent::__construct($context);
+    }
+
+    /**
+     * @param $method
+     * @param array $vars
+     * @return string
+     */
+    public function getId($method, $vars = array())
+    {
+        return base64_encode($this->storeId . self::CACHE_ID . $method . implode('', $vars));
+    }
+
+    /**
+     * @param $cacheId
+     * @return bool|string
+     */
+    public function load($cacheId)
+    {
+        if ($this->cacheState->isEnabled(self::CACHE_ID)) {
+            return $this->cache->load($cacheId);
+        }
+
+        return FALSE;
+    }
+
+    /**
+     * @param $data
+     * @param $cacheId
+     * @param int $cacheLifetime
+     * @return bool
+     */
+    public function save($data, $cacheId, $cacheLifetime = self::CACHE_LIFETIME)
+    {
+        if ($this->cacheState->isEnabled(self::CACHE_ID)) {
+            $this->cache->save($data, $cacheId, array(self::CACHE_TAG), $cacheLifetime);
+            return TRUE;
+        }
+        return FALSE;
+    }
+}

--- a/Model/Cache/Type.php
+++ b/Model/Cache/Type.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Magiccart\Magicmenu\Model\Cache;
+
+class Type extends \Magento\Framework\Cache\Frontend\Decorator\TagScope
+{
+/**
+* Cache type code unique among all cache types
+*/
+const TYPE_IDENTIFIER = 'megamenu';
+
+/**
+* Cache tag used to distinguish the cache type from all other cache
+*/
+const CACHE_TAG = 'MEGAMENU';
+
+/**
+* @param \Magento\Framework\App\Cache\Type\FrontendPool $cacheFrontendPool
+*/
+public function __construct(\Magento\Framework\App\Cache\Type\FrontendPool $cacheFrontendPool)
+{
+parent::__construct($cacheFrontendPool->get(self::TYPE_IDENTIFIER), self::CACHE_TAG);
+}
+
+}

--- a/etc/cache.xml
+++ b/etc/cache.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Cache/etc/cache.xsd">
+    <type name="megamenu" translate="label,description" instance="Magiccart\Magicmenu\Model\Cache\Type">
+        <label>Megamenu</label>
+        <description>Main Menu Cache</description>
+    </type>
+</config>

--- a/view/frontend/layout/default.xml
+++ b/view/frontend/layout/default.xml
@@ -21,5 +21,8 @@
             <block class="Magiccart\Magicmenu\Block\Menu" ifconfig="magicmenu/accordion/enabled" name="accordion.sidebar" before="-"
                    template="accordion.phtml" />
         </referenceContainer>
+        <referenceContainer name="content">
+            <block class="Magiccart\Magicmenu\Block\Menu" name="megamenu.active" after="-" template="active.phtml" />
+        </referenceContainer>
     </body>
 </page>

--- a/view/frontend/templates/active.phtml
+++ b/view/frontend/templates/active.phtml
@@ -6,8 +6,15 @@ $categoryId = ($this->getCurrentCategory()->getId())? $this->getCurrentCategory(
     require(['jquery'], function($) {
         $(document).ready(function () {
 
-            $(".magicmenu ul").find("[data-categoryid='<?php echo $categoryId ?>']").parent('li').addClass('active');
+            $(".magicmenu ul").find("[data-categoryid='<?php echo $categoryId ?>']").parents('li').addClass('active');
 
+         <?php
+            $accordion = $this->_sysCfg->accordion;
+            if($accordion['enabled']):
+            ?>
+                $(".accordion").find("[data-categoryid='<?php echo $categoryId ?>']").addClass('active');
+                $(".accordion").find("[data-categoryid='<?php echo $categoryId ?>']").parents('li').addClass('active');
+            <?php endif; ?>
         });
     });
 </script>

--- a/view/frontend/templates/active.phtml
+++ b/view/frontend/templates/active.phtml
@@ -1,0 +1,13 @@
+<?php
+$categoryId = ($this->getCurrentCategory()->getId())? $this->getCurrentCategory()->getId() : '';
+?>
+
+<script type="text/javascript">
+    require(['jquery'], function($) {
+        $(document).ready(function () {
+
+            $(".magicmenu ul").find("[data-categoryid='<?php echo $categoryId ?>']").parent('li').addClass('active');
+
+        });
+    });
+</script>


### PR DESCRIPTION
Adds Dedicated Menu Cache to reduce page load down.

On a regular uncached page, the mega menu would need to load from the database, creating excess load and poor performance for page speed TTFB.

Changes add a cache to the System / Cache. 

This means when Page Cache is flushed, it does not affect the mega menu cache and page TTFB.

Requires addtional changes to reneable the is active feature